### PR TITLE
Fix: Handle cases where the rel_check_df is empty 

### DIFF
--- a/workflow/rules/peddy.smk
+++ b/workflow/rules/peddy.smk
@@ -71,7 +71,7 @@ rule create_ped:
     output:
         temp("qc/peddy/all.ped"),
     log:
-        "qc/peddy/all.ped",
+        "qc/peddy/all.ped.log",
     resources:
         mem_mb=config.get("create_ped", {}).get("mem_mb", config["default_resources"]["mem_mb"]),
         mem_per_cpu=config.get("create_ped", {}).get("mem_per_cpu", config["default_resources"]["mem_per_cpu"]),

--- a/workflow/scripts/create_peddy_mqc_config.py
+++ b/workflow/scripts/create_peddy_mqc_config.py
@@ -96,9 +96,10 @@ def main():
             rel_check_df.sort_values(by=['trio_id'], inplace=True)
 
             # create sample pair column as the first column to be used in  multiqc table
-            rel_check_df['sample_pair'] = rel_check_df[['sample_a', 'sample_b']].agg('_v_'.join, axis=1)
-            first_column = rel_check_df.pop('sample_pair')
-            rel_check_df.insert(0, 'sample_pair', first_column)
+            if rel_check_df.shape[0] > 0:
+                rel_check_df['sample_pair'] = rel_check_df[['sample_a', 'sample_b']].agg('_v_'.join, axis=1)
+                first_column = rel_check_df.pop('sample_pair')
+                rel_check_df.insert(0, 'sample_pair', first_column)
             peddy_rel_config = peddy_mqc_configs.get('peddy_rel_check')
             write_peddy_mqc(rel_check_df, peddy_rel_config, snakemake.output.rel_check_mqc)
 


### PR DESCRIPTION
The rel_check_df is empty when there are no trios or errors reported by peddy. 

In such case an empty tsv file for multiqc is still written, but this will be ignored by multiqc and logged.